### PR TITLE
Take into account that a stats column can be NULL.

### DIFF
--- a/AzurePlot/AzurePlot.Lib/SQLDatabase/SQLDatabaseStatsClient.cs
+++ b/AzurePlot/AzurePlot.Lib/SQLDatabase/SQLDatabaseStatsClient.cs
@@ -79,6 +79,13 @@ namespace AzurePlot.Lib.SQLDatabase {
                                 continue;
                             }
 
+                            if (reader.IsDBNull(i)) {
+                                /* New column "avg_login_rate_percent" in sys.dm_db_resource_stats currently has NULL as 
+                                 * value, so just skip if that happens.
+                                 */
+                                continue;
+                            }
+
                             var value = Convert.ToDecimal(reader[i]);
 
                             result.Add(new UsageObject {


### PR DESCRIPTION
sys.dm_db_resource_stats has a new column "avg_login_rate_percent" that currently contains a NULL value.